### PR TITLE
Added ability to specify the type of your params when invoking a contract function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+.idea/

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -318,7 +318,8 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff"
+                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
+                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
             ],
             "version": "==0.6.0"
         },

--- a/README.rst
+++ b/README.rst
@@ -1,31 +1,6 @@
 NeoJsonRPC
 ##########
 
-.. image:: https://readthedocs.org/projects/neojsonrpc/badge/?version=stable
-    :target: https://neojsonrpc.readthedocs.org/en/stable/
-    :alt: Documentation Status
-
-.. image:: https://img.shields.io/pypi/l/neojsonrpc.svg
-    :target: https://pypi.python.org/pypi/neojsonrpc/
-    :alt: License
-
-.. image:: https://img.shields.io/pypi/pyversions/neojsonrpc.svg
-    :target: https://pypi.python.org/pypi/neojsonrpc
-
-.. image:: https://img.shields.io/pypi/v/neojsonrpc.svg
-    :target: https://pypi.python.org/pypi/neojsonrpc/
-    :alt: Latest Version
-
-.. image:: https://img.shields.io/travis/ellmetha/neojsonrpc.svg
-    :target: https://travis-ci.org/ellmetha/neojsonrpc
-    :alt: Build status
-
-.. image:: https://img.shields.io/codecov/c/github/ellmetha/neojsonrpc.svg
-    :target: https://codecov.io/github/ellmetha/neojsonrpc
-    :alt: Codecov status
-
-|
-
 **NeoJsonRPC** is a Python JSON-RPC client for the NEO blockchain. It implements the JSON-RPC
 methods of the API interface provided by NEO nodes (minus the methods requiring an opened wallet).
 The client also provides a high-level interface to invoke contract methods on the NEO blockchain.
@@ -50,7 +25,7 @@ To install NeoJsonRPC, please use pip_ (or pipenv_) as follows:
 
 .. code-block:: shell
 
-    $ pip install neojsonrpc
+    $ pip install git+https://github.com/jhwinter/neojsonrpc.git
 
 Basic usage
 ===========
@@ -111,7 +86,7 @@ You can also invoke smart contract functions using the following methods:
 Authors
 =======
 
-Morgan Aubert (`@ellmetha <https://github.com/ellmetha>`_) and contributors_. See ``AUTHORS`` for
+Morgan Aubert (`@ellmetha <https://github.com/ellmetha>`_), Jonathan Winter (`@jhwinter <https://github.com/jhwinter>`_)and contributors_. See ``AUTHORS`` for
 more details.
 
 .. _contributors: https://github.com/ellmetha/neojsonrpc/contributors

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 NeoJsonRPC
 ##########
 
+THIS PROJECT HAS BEEN ARCHIVED IN PREFERENCE OF neo-python-rpc. https://github.com/CityOfZion/neo-python-rpc
+
 **NeoJsonRPC** is a Python JSON-RPC client for the NEO blockchain. It implements the JSON-RPC
 methods of the API interface provided by NEO nodes (minus the methods requiring an opened wallet).
 The client also provides a high-level interface to invoke contract methods on the NEO blockchain.

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Online browsable documentation is available at https://neojsonrpc.readthedocs.io
 Requirements
 ============
 
-Python_ 3.4+, Requests_ 2.0+.
+Python_ 3.6+, Requests_ 2.0+.
 
 Installation
 ============
@@ -87,7 +87,8 @@ You can also invoke smart contract functions using the following methods:
 
     >>> from neojsonrpc import Client
     >>> client = Client.for_testnet()
-    >>> result = client.invoke_function('34af1b6634fcd7cfcff0158965b18601d3837e32', 'symbol', [])
+    >>> result = client.invoke_function('34af1b6634fcd7cfcff0158965b18601d3837e32', False, 'symbol',
+    [])
     {'gas_consumed': '0.217',
      'stack': [{'type': 'ByteArray', 'value': bytearray(b'TKN')}],
      'state': 'HALT, BREAK'}
@@ -96,6 +97,16 @@ You can also invoke smart contract functions using the following methods:
     {'gas_consumed': '0.217',
      'stack': [{'type': 'ByteArray', 'value': bytearray(b'TKN')}],
      'state': 'HALT, BREAK'}
+    >>> client.invoke_function('9aff1e08aea2048a26a3d2ddbb3df495b932b1e7', True, 'balanceOf', [{
+    'type': 5, 'value': '056320a11ec9b0e1c6645f5b25cf7b2fc354fd49'}])
+    {'state': 'HALT, BREAK',
+    'gas_consumed': '0.345',
+    'stack': [{'type': 'ByteArray', 'value': bytearray(b'\x00P\xdb\xbb\xa6!')}]}
+    >>> client.contract('9aff1e08aea2048a26a3d2ddbb3df495b932b1e7').balanceOf(True,
+    {'type': 5, 'value': '056320a11ec9b0e1c6645f5b25cf7b2fc354fd49'})
+    {'state': 'HALT, BREAK',
+    'gas_consumed': '0.345',
+    'stack': [{'type': 'ByteArray', 'value': bytearray(b'\x00P\xdb\xbb\xa6!')}]}
 
 Authors
 =======

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -103,6 +103,12 @@ simple example using the ``invoke_function`` method:
      'stack': [{'type': 'ByteArray', 'value': bytearray(b'TKN')}],
      'state': 'HALT, BREAK'}
 
+    >>> client.invoke_function('9aff1e08aea2048a26a3d2ddbb3df495b932b1e7', True, 'balanceOf', [{
+    'type': 5, 'value': '056320a11ec9b0e1c6645f5b25cf7b2fc354fd49'}])
+    {'state': 'HALT, BREAK',
+    'gas_consumed': '0.345',
+    'stack': [{'type': 'ByteArray', 'value': bytearray(b'\x00P\xdb\xbb\xa6!')}]}
+
 It should be noted that NeoJsonRPC provides a more high-level interface for interacting with
 contract fonctions as if they were Python class instance methods:
 
@@ -113,3 +119,9 @@ contract fonctions as if they were Python class instance methods:
     {'gas_consumed': '0.217',
      'stack': [{'type': 'ByteArray', 'value': bytearray(b'TKN')}],
      'state': 'HALT, BREAK'}
+
+    >>> client.contract('9aff1e08aea2048a26a3d2ddbb3df495b932b1e7').balanceOf(True,
+    {'type': 5, 'value': '056320a11ec9b0e1c6645f5b25cf7b2fc354fd49'})
+    {'state': 'HALT, BREAK',
+    'gas_consumed': '0.345',
+    'stack': [{'type': 'ByteArray', 'value': bytearray(b'\x00P\xdb\xbb\xa6!')}]}

--- a/neojsonrpc/client.py
+++ b/neojsonrpc/client.py
@@ -22,6 +22,13 @@ class Client:
     """ The NEO JSON-RPC client class. """
 
     def __init__(self, host=None, port=None, tls=False, http_max_retries=None):
+        """ Initializes the Client used to connect to the blockchain
+
+        :param str host: host to connect to
+        :param int port: port to access
+        :param bool tls: whether or not to us Transport Layer Security Protocol
+        :param int http_max_retries: maximum amount of times the client will try to connect to a peer before it quits
+        """
         # Initializes attributes related to the client settings (host, port, etc).
         self.host = host or 'localhost'
         self.port = port or 30333
@@ -35,6 +42,10 @@ class Client:
         # after each request made to the JSON-RPC endpoint.
         self._id_counter = 0
 
+    # TODO: I want to make the hosts/ports more dynamic for for_mainnet() and for_testnet()
+    # I will probably try to use this project https://github.com/jhwinter/neo-python-protocol-maker to help keep the
+    # hosts/ports constantly updated. The client wasn't working when I first downloaded this project due to the
+    # hosts being down
     @classmethod
     def for_mainnet(cls):
         """ Creates a ``Client`` instance for use with the NEO Main Net. """
@@ -45,7 +56,7 @@ class Client:
         """ Creates a ``Client`` instance for use with the NEO Test Net. """
         return cls(host='seed3.neo.org', port=20332)
 
-    def contract(self, script_hash, has_type):
+    def contract(self, script_hash):
         """ Returns a ``ContractWrapper`` instance allowing to easily invoke contract functions.
 
         This method allows to invoke smart contract functions as if they were Python class instance
@@ -53,19 +64,19 @@ class Client:
 
         .. code-block:: python
 
+            >>> client = Client.for_testnet()
             >>> contract = client.contract('34af1b6634fcd7cfcff0158965b18601d3837e32')
             >>> contract.symbol()
             {...}
             >>> contract.getBalance('<address>')
             {...}
 
-        :param script_hash: contract script hash
-        :type script_hash: str
+        :param str script_hash: contract script hash
         :return: :class:`ContractWrapper <ContractWrapper>` object
         :rtype: neojsonrpc.client.ContractWrapper
 
         """
-        return ContractWrapper(self, script_hash, has_type)
+        return ContractWrapper(self, script_hash)
 
     ####################
     # JSON-RPC METHODS #
@@ -74,8 +85,7 @@ class Client:
     def get_account_state(self, address, **kwargs):
         """ Returns the account state information associated with a specific address.
 
-        :param address: a 34-bit length address (eg. AJBENSwajTzQtwyJFkiJSv7MAaaMc7DsRz)
-        :type address: str
+        :param str address: a 34-bit length address (eg. AJBENSwajTzQtwyJFkiJSv7MAaaMc7DsRz)
         :return: dictionary containing the account state information
         :rtype: dict
 
@@ -85,10 +95,9 @@ class Client:
     def get_asset_state(self, asset_id, **kwargs):
         """ Returns the asset information associated with a specific asset ID.
 
-        :param asset_id:
+        :param str asset_id:
             an asset identifier (the transaction ID of the RegistTransaction when the asset is
             registered)
-        :type asset_id: str
         :return: dictionary containing the asset state information
         :rtype: dict
 
@@ -107,13 +116,11 @@ class Client:
     def get_block(self, block_hash, verbose=True, **kwargs):
         """ Returns the block information associated with a specific hash value or block index.
 
-        :param block_hash: a block hash value or a block index (block height)
-        :param verbose:
+        :param str or int block_hash: a block hash value or a block index (block height)
+        :param bool verbose:
             a boolean indicating whether the detailed block information should be returned in JSON
             format (otherwise the block information is returned as an hexadecimal string by the
             JSON-RPC endpoint)
-        :type block_hash: str or int
-        :type verbose: bool
         :return:
             dictionary containing the block information (or an hexadecimal string if verbose is set
             to False)
@@ -134,8 +141,7 @@ class Client:
     def get_block_hash(self, block_index, **kwargs):
         """ Returns the hash value associated with a specific block index.
 
-        :param block_index: a block index (block height)
-        :type block_index: int
+        :param int block_index: a block index (block height)
         :return: hash of the block associated with the considered index
         :rtype: str
 
@@ -145,8 +151,7 @@ class Client:
     def get_block_sys_fee(self, block_index, **kwargs):
         """ Returns the system fees associated with a specific block index.
 
-        :param block_index: a block index (block height)
-        :type block_index: int
+        :param int block_index: a block index (block height)
         :return: system fees of the block, expressed in NeoGas units
         :rtype: str
 
@@ -165,8 +170,7 @@ class Client:
     def get_contract_state(self, script_hash, **kwargs):
         """ Returns the contract information associated with a specific script hash.
 
-        :param script_hash: contract script hash
-        :type script_hash: str
+        :param str script_hash: contract script hash
         :return: dictionary containing the contract information
         :rtype: dict
 
@@ -185,13 +189,11 @@ class Client:
     def get_raw_transaction(self, tx_hash, verbose=True, **kwargs):
         """ Returns detailed information associated with a specific transaction hash.
 
-        :param tx_hash: transaction hash
-        :param verbose:
+        :param str tx_hash: transaction hash
+        :param bool verbose:
             a boolean indicating whether the detailed transaction information should be returned in
             JSON format (otherwise the transaction information is returned as an hexadecimal string
             by the JSON-RPC endpoint)
-        :type tx_hash: str
-        :type verbose: bool
         :return:
             dictionary containing the transaction information (or an hexadecimal string if verbose
             is set to False)
@@ -203,10 +205,8 @@ class Client:
     def get_storage(self, script_hash, key, **kwargs):
         """ Returns the value stored in the storage of a contract script hash for a given key.
 
-        :param script_hash: contract script hash
-        :param key: key to look up in the storage
-        :type script_hash: str
-        :type key: str
+        :param str script_hash: contract script hash
+        :param str key: key to look up in the storage
         :return: value associated with the storage key
         :rtype: bytearray
 
@@ -223,11 +223,8 @@ class Client:
     def get_tx_out(self, tx_hash, index, **kwargs):
         """ Returns the transaction output information corresponding to a hash and index.
 
-        :param tx_hash: transaction hash
-        :param index:
-            index of the transaction output to be obtained in the transaction (starts from 0)
-        :type tx_hash: str
-        :type index: int
+        :param str tx_hash: transaction hash
+        :param int index: index of the transaction output to be obtained in the transaction (starts from 0)
         :return: dictionary containing the transaction output
         :rtype: dict
 
@@ -258,47 +255,37 @@ class Client:
         It should be noted that the name of the function invoked in the contract should be part of
         paramaters.
 
-        :param script_hash: contract script hash
-        :param params: list of paramaters to be passed in to the smart contract
-        :param has_type: whether or not the type is included with the params
-        :type script_hash: str
-        :type params: list
-        :type has_type: str or int
+        :param str script_hash: contract script hash
+        :param bool has_type: whether or not the type is included with the params
+        :param list params: list of paramaters to be passed in to the smart contract
         :return: result of the invocation
         :rtype: dictionary
 
         """
         contract_params = encode_invocation_params(has_type=has_type, params=params)
         raw_result = self._call(JSONRPCMethods.INVOKE.value, [script_hash, contract_params, ], **kwargs)
-        return decode_invocation_result(raw_result)
+        return decode_invocation_result(result=raw_result)
 
     def invoke_function(self, script_hash, operation, has_type, params, **kwargs):
         """ Invokes a contract's function with given parameters and returns the result.
 
-        :param script_hash: contract script hash
-        :param operation: name of the operation to invoke
-        :param params: list of paramaters to be passed in to the smart contract
-        :param has_type: whether or not the type is included with the params
-        :type script_hash: str
-        :type operation: str
-        :type params: list
-        :type has_type: bool
+        :param str script_hash: contract script hash
+        :param str operation: name of the operation to invoke
+        :param bool has_type: whether or not the type is included with the params
+        :param list params: list of parematers to be passed in to the smart contract
         :return: result of the invocation
         :rtype: dictionary
 
         """
         contract_params = encode_invocation_params(has_type=has_type, params=params)
-        print(f'CONTRACT PARAMS: {contract_params}')
         raw_result = self._call(JSONRPCMethods.INVOKE_FUNCTION.value, [script_hash, operation, contract_params, ],
                                 **kwargs)
-        print(f'RAW RESULT: {raw_result}')
-        return decode_invocation_result(raw_result)
+        return decode_invocation_result(result=raw_result)
 
     def invoke_script(self, script, **kwargs):
         """ Invokes a script on the VM and returns the result.
 
-        :param script: script runnable by the VM
-        :type script: str
+        :param str script: script runnable by the VM
         :return: result of the invocation
         :rtype: dictionary
 
@@ -309,8 +296,7 @@ class Client:
     def send_raw_transaction(self, hextx, **kwargs):
         """ Broadcasts a transaction over the NEO network and returns the result.
 
-        :param hextx: hexadecimal string that has been serialized
-        :type hextx: str
+        :param str hextx: hexadecimal string that has been serialized
         :return: result of the transaction
         :rtype: bool
 
@@ -320,8 +306,7 @@ class Client:
     def validate_address(self, addr, **kwargs):
         """ Validates if the considered string is a valid NEO address.
 
-        :param addr: string containing a potential NEO address
-        :type addr: str
+        :param str addr: string containing a potential NEO address
         :return: dictionary containing the result of the verification
         :rtype: dictionary
 
@@ -333,7 +318,14 @@ class Client:
     ##################################
 
     def _call(self, method, params=None, request_id=None):
-        """ Calls the JSON-RPC endpoint. """
+        """ Calls the JSON-RPC endpoint.
+
+        :param str method: method to be called
+        :param list params: parameters to be passed
+        :param int request_id: id required to help sort clients out
+        :return: results of the invocation
+        :rtype: dict
+        """
         params = params or []
 
         # Determines which 'id' value to use and increment the counter associated with the current
@@ -351,7 +343,7 @@ class Client:
 
         # Calls the JSON-RPC endpoint!
         try:
-            response = self.session.post(url, headers=headers, data=json.dumps(payload))
+            response = self.session.post(url=url, headers=headers, data=json.dumps(payload))
             response.raise_for_status()
         except HTTPError:
             raise TransportError(f'Got unsuccessful response from server (status code: {response.status_code}',
@@ -360,7 +352,6 @@ class Client:
         # Ensures the response body can be deserialized to JSON.
         try:
             response_data = response.json()
-            print(f'RESPONSE DATA: {response_data}')
         except ValueError as e:
             raise ProtocolError(f'Unable to deserialize response body: {e}', response=response)
 
@@ -378,29 +369,51 @@ class Client:
 class ContractWrapper:
     """ Strategy class allowing to provide a high-level interface for invoking smart contracts. """
 
-    def __init__(self, client, script_hash, has_type):
+    def __init__(self, client, script_hash):
+        """ Initialize the ContractWrapper
+
+        :param Client client: Client object
+        :param str script_hash: contract's script hash
+        """
         self.client = client
         self.script_hash = script_hash
-        self.has_type = has_type
 
     def __getattribute__(self, attr):
+        """
+
+        :param attr:
+        :return:
+        """
         try:
             return super(ContractWrapper, self).__getattribute__(attr)
         except AttributeError:
             client = super(ContractWrapper, self).__getattribute__('client')
             script_hash = super(ContractWrapper, self).__getattribute__('script_hash')
-            has_type = super(ContractWrapper, self).__getattribute__('has_type')
-            return ContractFunctionWrapper(client=client, script_hash=script_hash, has_type=has_type, funcname=attr)
+            return ContractFunctionWrapper(client=client, script_hash=script_hash, funcname=attr)
 
 
 class ContractFunctionWrapper:
     """ Strategy class allowing to easily invoke smart contract functions. """
 
-    def __init__(self, client, script_hash, funcname, has_type):
+    def __init__(self, client, script_hash, funcname):
+        """ Initialize the ContractFunctionWrapper
+
+        :param Client client: client used to connect to the JSON-RPC endpoints
+        :param str script_hash: script hash of the contract
+        :param str funcname: contract operation to be performed
+        """
         self.client = client
         self.script_hash = script_hash
         self.funcname = funcname
-        self.has_type = has_type
 
-    def __call__(self, *args):
-        return self.client.invoke_function(self.script_hash, self.funcname, self.has_type, args)
+    def __call__(self, has_type=False, *args):
+        """ This is executed when someone tries to execute a contract's operation
+
+        :param bool has_type:
+            whether or not the user is passing in the 'type' along with the 'value'.
+            if True, args must all be dict types
+        :param args:
+        :return: results of the function invocation
+        """
+        has_type = has_type or False
+        return self.client.invoke_function(self.script_hash, self.funcname, has_type, args)

--- a/neojsonrpc/client.py
+++ b/neojsonrpc/client.py
@@ -17,7 +17,11 @@ from .constants import JSONRPCMethods
 from .exceptions import ProtocolError, TransportError
 from .utils import decode_invocation_result, encode_invocation_params
 
-
+# TODO: add multirequest JSON support
+# From https://github.com/CityOfZion/neo-python/blob/978f77922247d2d85c63dfe8db66e856fcb56582/neo/api/JSONRPC/JsonRpcApi.py#L118
+# {"jsonrpc": "2.0", "id": 5, "method": "getblockcount", "params": []}
+# or multiple requests in 1 transaction
+# [{"jsonrpc": "2.0", "id": 1, "method": "getblock", "params": [10], {"jsonrpc": "2.0", "id": 2, "method": "getblock", "params": [10,1]}
 class Client:
     """ The NEO JSON-RPC client class. """
 

--- a/neojsonrpc/client.py
+++ b/neojsonrpc/client.py
@@ -38,12 +38,12 @@ class Client:
     @classmethod
     def for_mainnet(cls):
         """ Creates a ``Client`` instance for use with the NEO Main Net. """
-        return cls(host='seed1.cityofzion.io', port=8080)
+        return cls(host='seed1.ngd.network', port=10332)
 
     @classmethod
     def for_testnet(cls):
         """ Creates a ``Client`` instance for use with the NEO Test Net. """
-        return cls(host='test1.cityofzion.io', port=8880)
+        return cls(host='seed3.neo.org', port=20332)
 
     def contract(self, script_hash):
         """ Returns a ``ContractWrapper`` instance allowing to easily invoke contract functions.
@@ -120,8 +120,7 @@ class Client:
         :rtype: dict or str
 
         """
-        return self._call(
-            JSONRPCMethods.GET_BLOCK.value, params=[block_hash, int(verbose), ], **kwargs)
+        return self._call(JSONRPCMethods.GET_BLOCK.value, params=[block_hash, int(verbose), ], **kwargs)
 
     def get_block_count(self, **kwargs):
         """ Returns the number of blocks in the chain.
@@ -199,8 +198,7 @@ class Client:
         :rtype: dict or str
 
         """
-        return self._call(
-            JSONRPCMethods.GET_RAW_TRANSACTION.value, params=[tx_hash, int(verbose), ], **kwargs)
+        return self._call(JSONRPCMethods.GET_RAW_TRANSACTION.value, params=[tx_hash, int(verbose), ], **kwargs)
 
     def get_storage(self, script_hash, key, **kwargs):
         """ Returns the value stored in the storage of a contract script hash for a given key.
@@ -214,8 +212,7 @@ class Client:
 
         """
         hexkey = binascii.hexlify(key.encode('utf-8')).decode('utf-8')
-        hexresult = self._call(
-            JSONRPCMethods.GET_STORAGE.value, params=[script_hash, hexkey, ], **kwargs)
+        hexresult = self._call(JSONRPCMethods.GET_STORAGE.value, params=[script_hash, hexkey, ], **kwargs)
         try:
             assert hexresult
             result = bytearray(binascii.unhexlify(hexresult.encode('utf-8')))
@@ -270,8 +267,7 @@ class Client:
 
         """
         contract_params = encode_invocation_params(params)
-        raw_result = self._call(
-            JSONRPCMethods.INVOKE.value, [script_hash, contract_params, ], **kwargs)
+        raw_result = self._call(JSONRPCMethods.INVOKE.value, [script_hash, contract_params, ], **kwargs)
         return decode_invocation_result(raw_result)
 
     def invoke_function(self, script_hash, operation, params, **kwargs):
@@ -288,9 +284,8 @@ class Client:
 
         """
         contract_params = encode_invocation_params(params)
-        raw_result = self._call(
-            JSONRPCMethods.INVOKE_FUNCTION.value, [script_hash, operation, contract_params, ],
-            **kwargs)
+        raw_result = self._call(JSONRPCMethods.INVOKE_FUNCTION.value, [script_hash, operation, contract_params, ],
+                                **kwargs)
         return decode_invocation_result(raw_result)
 
     def invoke_script(self, script, **kwargs):
@@ -360,8 +355,7 @@ class Client:
         try:
             response_data = response.json()
         except ValueError as e:
-            raise ProtocolError(
-                'Unable to deserialize response body: {}'.format(e), response=response)
+            raise ProtocolError(f'Unable to deserialize response body: {e}', response=response)
 
         # Properly handles potential errors.
         if response_data.get('error'):
@@ -369,9 +363,7 @@ class Client:
             message = response_data['error'].get('message', '')
             raise ProtocolError(f'Error[{code}] {message}', response=response, data=response_data)
         elif 'result' not in response_data:
-            raise ProtocolError(
-                'Response is empty (result field is missing)', response=response,
-                data=response_data)
+            raise ProtocolError('Response is empty (result field is missing)', response=response, data=response_data)
 
         return response_data['result']
 

--- a/neojsonrpc/client.py
+++ b/neojsonrpc/client.py
@@ -27,7 +27,8 @@ class Client:
         :param str host: host to connect to
         :param int port: port to access
         :param bool tls: whether or not to us Transport Layer Security Protocol
-        :param int http_max_retries: maximum amount of times the client will try to connect to a peer before it quits
+        :param int http_max_retries: maximum amount of times the client will try to connect to a
+        peer before it quits
         """
         # Initializes attributes related to the client settings (host, port, etc).
         self.host = host or 'localhost'
@@ -43,8 +44,10 @@ class Client:
         self._id_counter = 0
 
     # TODO: I want to make the hosts/ports more dynamic for for_mainnet() and for_testnet()
-    # I will probably try to use this project https://github.com/jhwinter/neo-python-protocol-maker to help keep the
-    # hosts/ports constantly updated. The client wasn't working when I first downloaded this project due to the
+    # I will probably try to use this project
+    # https://github.com/jhwinter/neo-python-protocol-maker to help keep the
+    # hosts/ports constantly updated. The client wasn't working when I first downloaded this
+    # project due to the
     # hosts being down
     @classmethod
     def for_mainnet(cls):
@@ -127,7 +130,8 @@ class Client:
         :rtype: dict or str
 
         """
-        return self._call(JSONRPCMethods.GET_BLOCK.value, params=[block_hash, int(verbose), ], **kwargs)
+        return self._call(JSONRPCMethods.GET_BLOCK.value, params=[block_hash, int(verbose), ],
+                          **kwargs)
 
     def get_block_count(self, **kwargs):
         """ Returns the number of blocks in the chain.
@@ -200,7 +204,8 @@ class Client:
         :rtype: dict or str
 
         """
-        return self._call(JSONRPCMethods.GET_RAW_TRANSACTION.value, params=[tx_hash, int(verbose), ], **kwargs)
+        return self._call(JSONRPCMethods.GET_RAW_TRANSACTION.value,
+                          params=[tx_hash, int(verbose), ], **kwargs)
 
     def get_storage(self, script_hash, key, **kwargs):
         """ Returns the value stored in the storage of a contract script hash for a given key.
@@ -212,7 +217,8 @@ class Client:
 
         """
         hexkey = binascii.hexlify(key.encode('utf-8')).decode('utf-8')
-        hexresult = self._call(JSONRPCMethods.GET_STORAGE.value, params=[script_hash, hexkey, ], **kwargs)
+        hexresult = self._call(JSONRPCMethods.GET_STORAGE.value, params=[script_hash, hexkey, ],
+                               **kwargs)
         try:
             assert hexresult
             result = bytearray(binascii.unhexlify(hexresult.encode('utf-8')))
@@ -224,7 +230,8 @@ class Client:
         """ Returns the transaction output information corresponding to a hash and index.
 
         :param str tx_hash: transaction hash
-        :param int index: index of the transaction output to be obtained in the transaction (starts from 0)
+        :param int index: index of the transaction output to be obtained in the transaction (
+        starts from 0)
         :return: dictionary containing the transaction output
         :rtype: dict
 
@@ -263,7 +270,8 @@ class Client:
 
         """
         contract_params = encode_invocation_params(has_type=has_type, params=params)
-        raw_result = self._call(JSONRPCMethods.INVOKE.value, [script_hash, contract_params, ], **kwargs)
+        raw_result = self._call(JSONRPCMethods.INVOKE.value, [script_hash, contract_params, ],
+                                **kwargs)
         return decode_invocation_result(result=raw_result)
 
     def invoke_function(self, script_hash, operation, has_type, params, **kwargs):
@@ -278,7 +286,8 @@ class Client:
 
         """
         contract_params = encode_invocation_params(has_type=has_type, params=params)
-        raw_result = self._call(JSONRPCMethods.INVOKE_FUNCTION.value, [script_hash, operation, contract_params, ],
+        raw_result = self._call(JSONRPCMethods.INVOKE_FUNCTION.value,
+                                [script_hash, operation, contract_params, ],
                                 **kwargs)
         return decode_invocation_result(result=raw_result)
 
@@ -346,8 +355,9 @@ class Client:
             response = self.session.post(url=url, headers=headers, data=json.dumps(payload))
             response.raise_for_status()
         except HTTPError:
-            raise TransportError(f'Got unsuccessful response from server (status code: {response.status_code}',
-                                 response=response)
+            raise TransportError(
+                f'Got unsuccessful response from server (status code: {response.status_code}',
+                response=response)
 
         # Ensures the response body can be deserialized to JSON.
         try:
@@ -361,7 +371,8 @@ class Client:
             message = response_data['error'].get('message', '')
             raise ProtocolError(f'Error[{code}] {message}', response=response, data=response_data)
         elif 'result' not in response_data:
-            raise ProtocolError('Response is empty (result field is missing)', response=response, data=response_data)
+            raise ProtocolError('Response is empty (result field is missing)', response=response,
+                                data=response_data)
 
         return response_data['result']
 

--- a/neojsonrpc/client.py
+++ b/neojsonrpc/client.py
@@ -220,10 +220,8 @@ class Client:
         hexkey = binascii.hexlify(key.encode('utf-8')).decode('utf-8')
         hexresult = self._call(JSONRPCMethods.GET_STORAGE.value, [script_hash, hexkey], **kwargs)
         try:
-            print(f'get_storage HEXRESULT: {hexresult}')
             assert hexresult
             result = bytearray(binascii.unhexlify(hexresult.encode('utf-8')))
-            print(f'RESULT: {result}')
         except AssertionError:
             result = hexresult
         return result
@@ -352,10 +350,7 @@ class Client:
 
         # Calls the JSON-RPC endpoint!
         try:
-            print(f'REQUEST: {json.dumps(payload)}'
-                  f'HEADERS: {self.session.headers}    url: {url}')
             response = self.session.post(url=url, data=json.dumps(payload))
-            print(f'REQUEST: {response.content}')
             response.raise_for_status()
         except HTTPError:
             raise TransportError(

--- a/neojsonrpc/client.py
+++ b/neojsonrpc/client.py
@@ -319,8 +319,8 @@ class Client:
     def validate_address(self, addr, **kwargs):
         """ Validates if the considered string is a valid NEO address.
 
-        :param hex: string containing a potential NEO address
-        :type hex: str
+        :param addr: string containing a potential NEO address
+        :type addr: str
         :return: dictionary containing the result of the verification
         :rtype: dictionary
 
@@ -345,17 +345,16 @@ class Client:
         payload = {'jsonrpc': '2.0', 'method': method, 'params': params, 'id': rid}
         headers = {'Content-Type': 'application/json'}
         scheme = 'https' if self.tls else 'http'
-        url = '{}://{}:{}'.format(scheme, self.host, self.port)
+        url = f'{scheme}://{self.host}:{self.port}'
+        response = ''  # setting this to an empty string to remove a warning message
 
         # Calls the JSON-RPC endpoint!
         try:
             response = self.session.post(url, headers=headers, data=json.dumps(payload))
             response.raise_for_status()
         except HTTPError:
-            raise TransportError(
-                'Got unsuccessful response from server (status code: {})'.format(
-                    response.status_code),
-                response=response)
+            raise TransportError(f'Got unsuccessful response from server (status code: {response.status_code}',
+                                 response=response)
 
         # Ensures the response body can be deserialized to JSON.
         try:
@@ -368,8 +367,7 @@ class Client:
         if response_data.get('error'):
             code = response_data['error'].get('code', '')
             message = response_data['error'].get('message', '')
-            raise ProtocolError(
-                'Error[{}] {}'.format(code, message), response=response, data=response_data)
+            raise ProtocolError(f'Error[{code}] {message}', response=response, data=response_data)
         elif 'result' not in response_data:
             raise ProtocolError(
                 'Response is empty (result field is missing)', response=response,

--- a/neojsonrpc/constants.py
+++ b/neojsonrpc/constants.py
@@ -70,13 +70,13 @@ class JSONRPCMethods(Enum):
 
     # The 'invoke' method allows to invoke a contract (associated with a specific script hash) with
     # potential parameters and to return the result. It should be noted that calling this method
-    # does not affect the blockchain in any way: the targetted contract is executed with the given
+    # does not affect the blockchain in any way: the targeted contract is executed with the given
     # parameters but the contract's storage remain unchanged.
     INVOKE = 'invoke'
 
     # The 'invokefunction' method allows to invoke a contract (associated with a specific script
     # hash) by specifying an operation and potential parameters. It should be noted that calling
-    # this method does not affect the blockchain in any way: the targetted contract is executed with
+    # this method does not affect the blockchain in any way: the targeted contract is executed with
     # the given parameters but the contract's storage remain unchanged.
     INVOKE_FUNCTION = 'invokefunction'
 

--- a/neojsonrpc/utils.py
+++ b/neojsonrpc/utils.py
@@ -51,6 +51,8 @@ def encode_invocation_params(has_type=False, params=None):
     :return: Returns a list of parameters meant to be passed to JSON-RPC endpoints.
     """
     final_params = []
+    if has_type and isinstance(params, dict):
+        final_params.append(params)
     for p in params:
         if has_type and isinstance(p, dict):
             final_params.append(p)
@@ -68,7 +70,10 @@ def encode_invocation_params(has_type=False, params=None):
             elif isinstance(p, str):
                 final_params.append({'type': ContractParameterTypes.STRING.value, 'value': p})
             elif isinstance(p, list):
-                innerp = encode_invocation_params(params=p)
+                if p and isinstance(p[0], dict) and 'type' in p[0]:
+                    innerp = encode_invocation_params(has_type=True, params=p)
+                else:
+                    innerp = encode_invocation_params(params=p)
                 final_params.append({'type': ContractParameterTypes.ARRAY.value, 'value': innerp})
     return final_params
 

--- a/neojsonrpc/utils.py
+++ b/neojsonrpc/utils.py
@@ -70,4 +70,6 @@ def _decode_invocation_result_stack(stack):
             value_dict['value'] = _decode_invocation_result_stack(value_dict['value'])
         elif value_dict['type'] == 'ByteArray':
             value_dict['value'] = bytearray(binascii.unhexlify(value_dict['value'].encode('utf-8')))
+        elif value_dict['type'] == 'Integer':
+            value_dict['value'] = value_dict['value']
     return stack

--- a/neojsonrpc/utils.py
+++ b/neojsonrpc/utils.py
@@ -45,7 +45,8 @@ def is_hash160(s):
 def encode_invocation_params(has_type=False, params=None):
     """ Returns a list of parameters meant to be passed to JSON-RPC endpoints.
 
-    :param bool has_type: whether or not the user has defined the 'type' of the 'value' they're passing
+    :param bool has_type: whether or not the user has defined the 'type' of the 'value' they're
+    passing
     :param list params: list of parameters
     :return: Returns a list of parameters meant to be passed to JSON-RPC endpoints.
     """

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -4,12 +4,14 @@ from neojsonrpc import Client
 class TestClient:
     def test_can_return_the_state_of_an_account(self):
         client = Client.for_testnet()
+        client.tls = True
         account = client.get_account_state('ALn85kUVLWWZdCuZfvjwbmusWH9Hx43XuF')
         assert 'balances' in account
         assert account['balances']
 
     def test_can_return_the_state_of_an_asset(self):
         client = Client.for_testnet()
+        client.tls = True
         asset = client.get_asset_state(
             'c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b')  # NEO
         assert asset['amount'] == '100000000'
@@ -18,46 +20,55 @@ class TestClient:
 
     def test_can_return_the_best_block_hash(self):
         client = Client.for_testnet()
+        client.tls = True
         best_block_hash = client.get_best_block_hash()
         assert len(best_block_hash[2:]) == 64
 
     def test_can_return_block_information_associated_with_a_block_hash(self):
         client = Client.for_testnet()
+        client.tls = True
         block = client.get_block('9e38052ac0827e490b917bd69174cfa0fae9a7f77db18ed3cf2ee95922e0103d')
         assert block['hash'] == '0x9e38052ac0827e490b917bd69174cfa0fae9a7f77db18ed3cf2ee95922e0103d'
         assert block['index']
 
     def test_can_return_the_block_count(self):
         client = Client.for_testnet()
+        client.tls = True
         assert client.get_block_count() > 0
 
     def test_can_return_the_block_hash_associated_with_an_index(self):
         client = Client.for_testnet()
+        client.tls = True
         block_hash = client.get_block_hash(970238)
         assert block_hash == '0x631be7a0fc5bc684bd756003576d5b9ecccb096a636d5e86e951513d3bba537c'
 
     def test_can_return_system_fees_associated_with_a_block_hash(self):
         client = Client.for_testnet()
+        client.tls = True
         fees = client.get_block_sys_fee(966045)
         assert fees == '716234'
 
     def test_can_return_the_connection_count(self):
         client = Client.for_testnet()
+        client.tls = True
         connection_count = client.get_connection_count()
         assert connection_count
 
     def test_can_return_the_state_of_a_contract(self):
         client = Client.for_testnet()
+        client.tls = True
         contract = client.get_contract_state('f9572c5b119a6b5775a6af07f1cef5d310038f55')
         assert contract['hash'] == '0xf9572c5b119a6b5775a6af07f1cef5d310038f55'
 
     def test_can_return_a_list_of_unconfirmed_transactions_associated_with_the_node(self):
         client = Client.for_testnet()
+        client.tls = True
         mempool = client.get_raw_mem_pool()
         assert isinstance(mempool, list)
 
     def test_can_return_detailed_information_associated_with_a_transaction_hash(self):
         client = Client.for_testnet()
+        client.tls = True
         tx = client.get_raw_transaction(
             'b96bd2b0070a4b25f47b390225da100b96ddcbe28c9af1f34cbb34462bf3db22')
         assert tx['txid'] == '0xb96bd2b0070a4b25f47b390225da100b96ddcbe28c9af1f34cbb34462bf3db22'
@@ -66,6 +77,7 @@ class TestClient:
 
     def test_can_return_a_value_stored_in_the_storage_of_a_specific_contract(self):
         client = Client.for_testnet()
+        client.tls = True
         val = client.get_storage('34af1b6634fcd7cfcff0158965b18601d3837e32', 'totalSupply')
         assert isinstance(val, bytearray)
         val = int.from_bytes(val, 'little')
@@ -74,35 +86,48 @@ class TestClient:
 
     def test_can_return_the_transaction_output_information_associated_with_a_hash_and_index(self):
         client = Client.for_testnet()
+        client.tls = True
         txout = client.get_tx_out(
             '6ed78234b2d4ac886f4f6246a19d237be38d6541e59d87b547987778314bb7af', 0)
         assert txout is None
 
     def test_can_return_node_peers(self):
         client = Client.for_testnet()
+        client.tls = True
         peers = client.get_peers()
         assert peers
 
+    def test_can_return_node_version(self):
+        client = Client.for_testnet()
+        client.tls = True
+        version = client.get_version()
+        assert version
+
     def test_can_invoke_a_contract(self):
         client = Client.for_testnet()
-        result = client.invoke('34af1b6634fcd7cfcff0158965b18601d3837e32', ['symbol', []])
+        client.tls = True
+        result = client.invoke('34af1b6634fcd7cfcff0158965b18601d3837e32', False, ['symbol', []])
         assert result['state'] == 'HALT, BREAK'
         assert result['stack'] == [{'type': 'ByteArray', 'value': bytearray(b'FOX')}]
 
     def test_can_invoke_a_contract_with_a_specific_function(self):
         client = Client.for_testnet()
-        result = client.invoke_function('34af1b6634fcd7cfcff0158965b18601d3837e32', 'symbol', [])
+        client.tls = True
+        result = client.invoke_function('34af1b6634fcd7cfcff0158965b18601d3837e32', False,
+                                        'symbol', [])
         assert result['state'] == 'HALT, BREAK'
         assert result['stack'] == [{'type': 'ByteArray', 'value': bytearray(b'FOX')}]
 
     def test_can_invoke_a_contract_using_a_script(self):
         client = Client.for_testnet()
+        client.tls = True
         result = client.invoke_script('000673796d626f6c67327e83d30186b1658915f0cfcfd7fc34661baf34')
         assert result['state'] == 'HALT, BREAK'
         assert result['stack'] == [{'type': 'ByteArray', 'value': bytearray(b'FOX')}]
 
     def test_can_send_a_raw_transaction(self):
         client = Client.for_testnet()
+        client.tls = True
         result = client.send_raw_transaction(
             '80000001195876cb34364dc38b730077156c6bc3a7fc570044a66fbfeeea56f71327e8ab0000029b7cffda'
             'a674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500c65eaf440000000f9a23e06f74cf'
@@ -115,11 +140,41 @@ class TestClient:
 
     def test_can_validate_an_address(self):
         client = Client.for_testnet()
+        client.tls = True
         assert client.validate_address('ASkaarMYjqdbcBpvLTFNXJhyonXR8K9Xx3')['isvalid']
         assert not client.validate_address('A=BSkaarMYjqdbcBpvLTFNXJhyonXR8K9Xx3')['isvalid']
 
     def test_can_invoke_a_contract_function_as_a_method(self):
         client = Client.for_testnet()
+        client.tls = True
         result = client.contract('34af1b6634fcd7cfcff0158965b18601d3837e32').symbol()
         assert result['state'] == 'HALT, BREAK'
         assert result['stack'] == [{'type': 'ByteArray', 'value': bytearray(b'FOX')}]
+
+    def test_can_invoke_a_contract_with_type(self):
+        client = Client.for_testnet()
+        client.tls = True
+        result = client.invoke('9aff1e08aea2048a26a3d2ddbb3df495b932b1e7', True,
+                               ['balanceOf',
+                                [{'type': 5, 'value': '017caf695f92b540abf388355792566595f84723'}]])
+        assert result['state'] == 'HALT, BREAK'
+        assert result['stack'] == [{'type': 'ByteArray', 'value': bytearray(b'\x000\xef}\xba\x02')}]
+
+    def test_can_invoke_a_contract_function_with_type(self):
+        client = Client.for_testnet()
+        client.tls = True
+        result = client.invoke_function('9aff1e08aea2048a26a3d2ddbb3df495b932b1e7', True,
+                                        'balanceOf', [
+                                            {'type': 5,
+                                             'value': '017caf695f92b540abf388355792566595f84723'}
+                                        ])
+        assert result['state'] == 'HALT, BREAK'
+        assert result['stack'] == [{'type': 'ByteArray', 'value': bytearray(b'\x000\xef}\xba\x02')}]
+
+    def test_can_invoke_a_contract_function_as_a_method_with_type(self):
+        client = Client.for_testnet()
+        client.tls = True
+        result = client.contract('9aff1e08aea2048a26a3d2ddbb3df495b932b1e7').balanceOf(
+            True, {'type': 5, 'value': '017caf695f92b540abf388355792566595f84723'})
+        assert result['state'] == 'HALT, BREAK'
+        assert result['stack'] == [{'type': 'ByteArray', 'value': bytearray(b'\x000\xef}\xba\x02')}]

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -72,7 +72,7 @@ class TestClient:
         assert val == 100000000000
         assert not client.get_storage('34af1b6634fcd7cfcff0158965b18601d3837e32', 'dummyKey')
 
-    def test_can_return_the_transaction_ouyput_information_associated_with_a_hash_and_index(self):
+    def test_can_return_the_transaction_output_information_associated_with_a_hash_and_index(self):
         client = Client.for_testnet()
         txout = client.get_tx_out(
             '6ed78234b2d4ac886f4f6246a19d237be38d6541e59d87b547987778314bb7af', 0)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -93,3 +93,19 @@ class TestDecodeInvocationResultHelper:
                                       'value': bytearray(b'https://neo.org')}]}],
                 'state': 'HALT, BREAK',
                 'tx': '00000', }
+
+    def test_can_decode_integer_values(self):
+        result = {
+            'gas_consumed': '0.334',
+            'script': '00000',
+            'stack': [{'type': 'Integer', 'value': 4}],
+            'state': 'HALT, BREAK',
+            'tx': '00000',
+        }
+        assert decode_invocation_result(result) == \
+            {
+                'gas_consumed': '0.334',
+                'script': '00000',
+                'stack': [{'type': 'Integer', 'value': 4}],
+                'state': 'HALT, BREAK',
+                'tx': '00000', }

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -98,7 +98,7 @@ class TestDecodeInvocationResultHelper:
         result = {
             'gas_consumed': '0.334',
             'script': '00000',
-            'stack': [{'type': 'Integer', 'value': 4}],
+            'stack': [{'type': 'Integer', 'value': '4'}],
             'state': 'HALT, BREAK',
             'tx': '00000',
         }

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -17,35 +17,38 @@ def test_is_hash160_helper_works():
 
 class TestEncodeInvocationParamsHelper:
     def test_can_encode_a_boolean(self):
-        assert encode_invocation_params(True, [True, False, ]) == \
+        assert encode_invocation_params(False, [True, False, ]) == \
             [{'type': 'Boolean', 'value': True}, {'type': 'Boolean', 'value': False}, ]
 
     def test_can_encode_an_integer(self):
-        assert encode_invocation_params(True, [42, ]) == [{'type': 'Integer', 'value': 42}, ]
+        assert encode_invocation_params(False, [42, ]) == [{'type': 'Integer', 'value': 42}, ]
 
     def test_can_encode_a_hash256(self):
-        assert encode_invocation_params(True,
-            ['936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af', ]) == \
-            [{'type': 'Hash256',
-              'value': '936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af'}, ]
+        assert encode_invocation_params(
+            False,
+            ['936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af']) == [
+            {'type': 'Hash256',
+             'value': '936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af'}]
 
     def test_can_encode_a_hash160(self):
-        assert encode_invocation_params(True,
-            ['98c615784ccb5fe5936fbc0cbe9dfdb408d92f0f', ]) == \
+        assert encode_invocation_params(False, ['98c615784ccb5fe5936fbc0cbe9dfdb408d92f0f', ]) == \
             [{'type': 'Hash160', 'value': '98c615784ccb5fe5936fbc0cbe9dfdb408d92f0f'}, ]
 
     def test_can_encode_a_byte_array(self):
-        assert encode_invocation_params(True, [bytearray('test'.encode('utf-8')), ]) == \
+        assert encode_invocation_params(False, [bytearray('test'.encode('utf-8')), ]) == \
             [{'type': 'ByteArray', 'value': bytearray('test'.encode('utf-8'))}, ]
 
     def test_can_encode_a_string(self):
-        assert encode_invocation_params(True, ['Hello', ]) == [{'type': 'String', 'value': 'Hello'}, ]
+        assert encode_invocation_params(False, ['Hello', ]) == [
+            {'type': 'String', 'value': 'Hello'}, ]
 
     def test_can_encode_an_array(self):
-        assert encode_invocation_params(True, [[1, 3, 6], ]) == \
-            [{'type': 'Array',
-              'value': [{'type': 'Integer', 'value': 1}, {'type': 'Integer', 'value': 3},
-                        {'type': 'Integer', 'value': 6}]}]
+        assert encode_invocation_params(False, [[1, 3, 6], ]) == \
+            [{
+                'type': 'Array',
+                'value': [{'type': 'Integer', 'value': 1}, {'type': 'Integer', 'value': 3},
+                          {'type': 'Integer', 'value': 6}]
+            }]
 
 
 class TestDecodeInvocationResultHelper:
@@ -72,15 +75,20 @@ class TestDecodeInvocationResultHelper:
                 'script': '00000',
                 'stack': [{'type': 'ByteArray', 'value': bytearray(b'https://neo.org')}],
                 'state': 'HALT, BREAK',
-                'tx': '00000', }
+                'tx': '00000',
+        }
 
     def test_can_decode_array_values(self):
         result = {
             'gas_consumed': '0.334',
             'script': '00000',
-            'stack': [{'type': 'Array',
-                       'value': [{'type': 'ByteArray',
-                                  'value': '68747470733a2f2f6e656f2e6f7267'}]}],
+            'stack': [{
+                'type': 'Array',
+                'value': [{
+                    'type': 'ByteArray',
+                    'value': '68747470733a2f2f6e656f2e6f7267'
+                }]
+            }],
             'state': 'HALT, BREAK',
             'tx': '00000',
         }
@@ -88,8 +96,13 @@ class TestDecodeInvocationResultHelper:
             {
                 'gas_consumed': '0.334',
                 'script': '00000',
-                'stack': [{'type': 'Array',
-                           'value': [{'type': 'ByteArray',
-                                      'value': bytearray(b'https://neo.org')}]}],
+                'stack': [{
+                    'type': 'Array',
+                    'value': [{
+                        'type': 'ByteArray',
+                        'value': bytearray(b'https://neo.org')
+                    }]
+                }],
                 'state': 'HALT, BREAK',
-                'tx': '00000', }
+                'tx': '00000',
+        }

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -17,32 +17,32 @@ def test_is_hash160_helper_works():
 
 class TestEncodeInvocationParamsHelper:
     def test_can_encode_a_boolean(self):
-        assert encode_invocation_params([True, False, ]) == \
+        assert encode_invocation_params(False, [True, False, ]) == \
             [{'type': 'Boolean', 'value': True}, {'type': 'Boolean', 'value': False}, ]
 
     def test_can_encode_an_integer(self):
-        assert encode_invocation_params([42, ]) == [{'type': 'Integer', 'value': 42}, ]
+        assert encode_invocation_params(False, [42, ]) == [{'type': 'Integer', 'value': 42}, ]
 
     def test_can_encode_a_hash256(self):
         assert encode_invocation_params(
-            ['936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af', ]) == \
+            False, ['936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af', ]) == \
             [{'type': 'Hash256',
               'value': '936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af'}, ]
 
     def test_can_encode_a_hash160(self):
-        assert encode_invocation_params(
-            ['98c615784ccb5fe5936fbc0cbe9dfdb408d92f0f', ]) == \
+        assert encode_invocation_params(False, ['98c615784ccb5fe5936fbc0cbe9dfdb408d92f0f', ]) == \
             [{'type': 'Hash160', 'value': '98c615784ccb5fe5936fbc0cbe9dfdb408d92f0f'}, ]
 
     def test_can_encode_a_byte_array(self):
-        assert encode_invocation_params([bytearray('test'.encode('utf-8')), ]) == \
+        assert encode_invocation_params(False, [bytearray('test'.encode('utf-8')), ]) == \
             [{'type': 'ByteArray', 'value': bytearray('test'.encode('utf-8'))}, ]
 
     def test_can_encode_a_string(self):
-        assert encode_invocation_params(['Hello', ]) == [{'type': 'String', 'value': 'Hello'}, ]
+        assert encode_invocation_params(False, ['Hello', ]) == [
+            {'type': 'String', 'value': 'Hello'}, ]
 
     def test_can_encode_an_array(self):
-        assert encode_invocation_params([[1, 3, 6], ]) == \
+        assert encode_invocation_params(False, [[1, 3, 6], ]) == \
             [{'type': 'Array',
               'value': [{'type': 'Integer', 'value': 1}, {'type': 'Integer', 'value': 3},
                         {'type': 'Integer', 'value': 6}]}]
@@ -106,6 +106,6 @@ class TestDecodeInvocationResultHelper:
             {
                 'gas_consumed': '0.334',
                 'script': '00000',
-                'stack': [{'type': 'Integer', 'value': 4}],
+                'stack': [{'type': 'Integer', 'value': '4'}],
                 'state': 'HALT, BREAK',
                 'tx': '00000', }

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -17,32 +17,32 @@ def test_is_hash160_helper_works():
 
 class TestEncodeInvocationParamsHelper:
     def test_can_encode_a_boolean(self):
-        assert encode_invocation_params([True, False, ]) == \
+        assert encode_invocation_params(True, [True, False, ]) == \
             [{'type': 'Boolean', 'value': True}, {'type': 'Boolean', 'value': False}, ]
 
     def test_can_encode_an_integer(self):
-        assert encode_invocation_params([42, ]) == [{'type': 'Integer', 'value': 42}, ]
+        assert encode_invocation_params(True, [42, ]) == [{'type': 'Integer', 'value': 42}, ]
 
     def test_can_encode_a_hash256(self):
-        assert encode_invocation_params(
+        assert encode_invocation_params(True,
             ['936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af', ]) == \
             [{'type': 'Hash256',
               'value': '936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af'}, ]
 
     def test_can_encode_a_hash160(self):
-        assert encode_invocation_params(
+        assert encode_invocation_params(True,
             ['98c615784ccb5fe5936fbc0cbe9dfdb408d92f0f', ]) == \
             [{'type': 'Hash160', 'value': '98c615784ccb5fe5936fbc0cbe9dfdb408d92f0f'}, ]
 
     def test_can_encode_a_byte_array(self):
-        assert encode_invocation_params([bytearray('test'.encode('utf-8')), ]) == \
+        assert encode_invocation_params(True, [bytearray('test'.encode('utf-8')), ]) == \
             [{'type': 'ByteArray', 'value': bytearray('test'.encode('utf-8'))}, ]
 
     def test_can_encode_a_string(self):
-        assert encode_invocation_params(['Hello', ]) == [{'type': 'String', 'value': 'Hello'}, ]
+        assert encode_invocation_params(True, ['Hello', ]) == [{'type': 'String', 'value': 'Hello'}, ]
 
     def test_can_encode_an_array(self):
-        assert encode_invocation_params([[1, 3, 6], ]) == \
+        assert encode_invocation_params(True, [[1, 3, 6], ]) == \
             [{'type': 'Array',
               'value': [{'type': 'Integer', 'value': 1}, {'type': 'Integer', 'value': 3},
                         {'type': 'Integer', 'value': 6}]}]
@@ -91,21 +91,5 @@ class TestDecodeInvocationResultHelper:
                 'stack': [{'type': 'Array',
                            'value': [{'type': 'ByteArray',
                                       'value': bytearray(b'https://neo.org')}]}],
-                'state': 'HALT, BREAK',
-                'tx': '00000', }
-
-    def test_can_decode_integer_values(self):
-        result = {
-            'gas_consumed': '0.334',
-            'script': '00000',
-            'stack': [{'type': 'Integer', 'value': '4'}],
-            'state': 'HALT, BREAK',
-            'tx': '00000',
-        }
-        assert decode_invocation_result(result) == \
-            {
-                'gas_consumed': '0.334',
-                'script': '00000',
-                'stack': [{'type': 'Integer', 'value': 4}],
                 'state': 'HALT, BREAK',
                 'tx': '00000', }


### PR DESCRIPTION
* Fixed issue where I wasn't able to connect to the testnet due to the node being down (I put in a TODO comment to make that more dynamic as well)
* Updated all of the formatted strings to use f-strings
* Provided a workaround for using the testnet due to getting an "[-400] Access denied" error when invoking smart contracts. The error appears to be a result of the refactoring from NEO 2.8 to Neo 2.9.
* User can specify the type of their parameters instead of relying on the encoding method that was originally in place. I added this to fix an issue where I wasn't able to invoke a token's 'balanceOf' operation due to my 'ByteArray' param being encoded as a 'Hash160' param. 
* Added some more tests in accordance with the additions
* Updated some documentation to reflect the changes I made